### PR TITLE
Solved ionicon issue in github deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:100,300,400,600" rel="stylesheet" type="text/css" />
-  <link href="http://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css" rel="stylesheet" type="text/css" />
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/ionicons/2.0.1/css/ionicons.min.css" rel="stylesheet" type="text/css" />
   <link type="text/css" rel="stylesheet" href="style.css" />
   <title>Budgety</title>
 </head>


### PR DESCRIPTION
Ionicon issue was caused because of http based cdn for ionicon css library, however github demands https connection, since it is by default a https page. When ran on local machine, it works fine, since local machine doesn't bother if it is http or https request.

I replaced older cdn link with an https based link, so it works fine, You can have a look here: https://omkarph.github.io/Budgety/
This github page is valid only until I keep the forked repo, so it won't work in future:)